### PR TITLE
Add refund function

### DIFF
--- a/contracts/Crowdfunding.sol
+++ b/contracts/Crowdfunding.sol
@@ -29,8 +29,8 @@ contract Crowdfunding {
     }
 
     struct Profile {
-        Crowdfunding.Contribution[] contributions;
-        Crowdfunding.Campaign[] createdCampaigns;
+        Contribution[] contributions;
+        Campaign[] createdCampaigns;
     }
 
     // Struct to represent a crowdfunding campaign
@@ -257,5 +257,13 @@ contract Crowdfunding {
         uint256 _campaignId
     ) public view returns (address[] memory) {
         return campaigns[_campaignId].contributors;
+    }
+
+    function getContributedCampaigns() public view returns (Contribution[] memory) {
+        return userProfileMap[msg.sender].contributions;
+    }
+
+    function getCreatedCampaigns() public view returns (Campaign[] memory) {
+        return userProfileMap[msg.sender].createdCampaigns;
     }
 }

--- a/test/Crowdfunding.js
+++ b/test/Crowdfunding.js
@@ -66,6 +66,24 @@ describe("Crowdfunding", function () {
                 expect(e.message).to.include("Invalid page number");
             }
         });
+
+        it("Should return all campaigns user has created", async () => {
+            await crowdfunding.connect(address1.address);
+            const user1Campaigns = await crowdfunding.connect(address1).getCreatedCampaigns();
+            const user2Campaigns = await crowdfunding.connect(address2).getCreatedCampaigns();
+
+            expect(user1Campaigns.length).to.equal(5);
+            expect(user2Campaigns.length).to.equal(0);
+        });
+
+        it("Should return all campaigns user has contributed to", async () => {
+            await crowdfunding.connect(address2).contribute(1, {value: etherToWei("2")});
+            const user1Campaigns = await crowdfunding.connect(address1).getContributedCampaigns();
+            const user2Campaigns = await crowdfunding.connect(address2).getContributedCampaigns();
+
+            expect(user1Campaigns.length).to.equal(0);
+            expect(user2Campaigns.length).to.equal(1);
+        });
     });
 
     describe("Refund", async () => {


### PR DESCRIPTION
### Notes
- Added `userContributionMap` and replaced `user2Campaigns` with `userCampaignMap`
- Added refund function
- Added refund to single user related tests, pending refund all user since it's an internal function
- Added a new struct Profile that contains both contributions and created campaigns of a user
- Added getters for created campaign and contributed campaign

### Testing
```
    Refund
      ✔ Should refund when requested
      ✔ Should not refund when requester is creator
      ✔ Should not refund when already refunded
```